### PR TITLE
SetNoteCompleteXML can now update last-change-date

### DIFF
--- a/src/dbus/remotecontrol.cpp
+++ b/src/dbus/remotecontrol.cpp
@@ -330,7 +330,7 @@ bool RemoteControl::SetNoteCompleteXml(const Glib::ustring& uri,
     return false;
   }
     
-  note->load_foreign_note_xml(xml_contents, CONTENT_CHANGED);
+  note->load_foreign_note_xml(xml_contents, OTHER_DATA_CHANGED);
   return true;
 }
 


### PR DESCRIPTION
I wrote a script to set the Modified date on a note using the DBus method SetNoteCompleteXML, and discovered that it was always updated to the current time instead of the time I wanted.

This patch calls load_foreign_note_xml with changeType=OTHER_DATA_CHANGED, rather than CONTENT_CHANGED. This is the same way load_foreign_note_xml is called in the synchronization code.   The result is that load_foreign_note_xml doesn't overwrite the last-change-date in the incoming XML, though it does still overwrite the last-metadata-change-date. 