### PR TITLE
Gtk+ 3.20 required

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ Gnote uses GNU Autotool for its build system, so compiling it is a standard:
 Dependencies:
 - Glibmm 2.32
 - Gtkmm 3.10
-- Gtk+ 3.10
+- Gtk+ 3.20
 - libxml2
 - libxslt
 - libuuid


### PR DESCRIPTION
autogen.sh complains if GTK+ < 3.20
| Requested 'gtk+-3.0 >= 3.20' but version of GTK+ is 3.18.9